### PR TITLE
Node version .nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-iron
+lts/iron


### PR DESCRIPTION
Set correct node version identifier in nvmrc to enable auto-setting the correct node version through nvm.
Run `nvm ls-remote` to see valid identifiers.